### PR TITLE
WebClient response 매핑 방법 수정 및 북마크 생성 API 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,11 @@ dependencies {
 
 	//WebClient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	//Gson
-	implementation 'com.google.code.gson:gson:2.9.0'
 	//S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
+
 }
 
 

--- a/src/main/java/porori/backend/community/config/BaseResponse.java
+++ b/src/main/java/porori/backend/community/config/BaseResponse.java
@@ -1,26 +1,27 @@
 package porori.backend.community.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import static porori.backend.community.config.BaseResponseStatus.SUCCESS;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
-@JsonPropertyOrder({"code", "message", "result"})
+@JsonPropertyOrder({"statusCode", "message", "data"})
 public class BaseResponse<T> {//BaseResponse 객체를 사용할때 성공 경우
-    private final String message;
-    private final int code;
+    private String message;
+    private int statusCode;
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private T result;
+    private T data;
 
     // 요청에 성공한 경우
-    public BaseResponse(T result) {
+    public BaseResponse(T data) {
         this.message = SUCCESS.getMessage();
-        this.code = SUCCESS.getCode();
-        this.result = result;
+        this.statusCode = SUCCESS.getCode();
+        this.data = data;
     }
 }

--- a/src/main/java/porori/backend/community/config/exception/bookmark/AlreadyBookmarkException.java
+++ b/src/main/java/porori/backend/community/config/exception/bookmark/AlreadyBookmarkException.java
@@ -1,0 +1,9 @@
+package porori.backend.community.config.exception.bookmark;
+
+import static porori.backend.community.config.exception.bookmark.BookmarkExceptionList.ALREADY_BOOKMARK_ERROR;
+
+public class AlreadyBookmarkException extends BookmarkException{
+    public AlreadyBookmarkException() {
+        super(ALREADY_BOOKMARK_ERROR.getErrorCode(), ALREADY_BOOKMARK_ERROR.getHttpStatus(), ALREADY_BOOKMARK_ERROR.getMessage());
+    }
+}

--- a/src/main/java/porori/backend/community/config/exception/bookmark/BookmarkException.java
+++ b/src/main/java/porori/backend/community/config/exception/bookmark/BookmarkException.java
@@ -1,0 +1,10 @@
+package porori.backend.community.config.exception.bookmark;
+
+import org.springframework.http.HttpStatus;
+import porori.backend.community.config.exception.ApplicationException;
+
+public class BookmarkException extends ApplicationException {
+    protected BookmarkException(String errorCode, HttpStatus httpStatus, String message) {
+        super(errorCode, httpStatus, message);
+    }
+}

--- a/src/main/java/porori/backend/community/config/exception/bookmark/BookmarkExceptionList.java
+++ b/src/main/java/porori/backend/community/config/exception/bookmark/BookmarkExceptionList.java
@@ -1,0 +1,15 @@
+package porori.backend.community.config.exception.bookmark;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BookmarkExceptionList {
+    MY_POST_ERROR("B0001", HttpStatus.FORBIDDEN, "자신의 게시글에는 북마크를 생성할 수 없습니다."),
+    ALREADY_BOOKMARK_ERROR("B0002", HttpStatus.CONFLICT, "이미 북마크된 게시글입니다.");
+    private final String errorCode;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/porori/backend/community/config/exception/bookmark/MyPostException.java
+++ b/src/main/java/porori/backend/community/config/exception/bookmark/MyPostException.java
@@ -1,0 +1,9 @@
+package porori.backend.community.config.exception.bookmark;
+
+import static porori.backend.community.config.exception.bookmark.BookmarkExceptionList.MY_POST_ERROR;
+
+public class MyPostException extends BookmarkException{
+    public MyPostException(){
+        super(MY_POST_ERROR.getErrorCode(), MY_POST_ERROR.getHttpStatus(), MY_POST_ERROR.getMessage());
+    }
+}

--- a/src/main/java/porori/backend/community/config/exception/post/NotFoundPostIdException.java
+++ b/src/main/java/porori/backend/community/config/exception/post/NotFoundPostIdException.java
@@ -1,0 +1,9 @@
+package porori.backend.community.config.exception.post;
+
+import static porori.backend.community.config.exception.post.PostExceptionList.NOT_FOUND_POSTID_ERROR;
+
+public class NotFoundPostIdException extends PostException{
+    public NotFoundPostIdException(){
+        super(NOT_FOUND_POSTID_ERROR.getErrorCode(), NOT_FOUND_POSTID_ERROR.getHttpStatus(), NOT_FOUND_POSTID_ERROR.getMessage());
+    }
+}

--- a/src/main/java/porori/backend/community/config/exception/post/PostException.java
+++ b/src/main/java/porori/backend/community/config/exception/post/PostException.java
@@ -1,0 +1,10 @@
+package porori.backend.community.config.exception.post;
+
+import org.springframework.http.HttpStatus;
+import porori.backend.community.config.exception.ApplicationException;
+
+public abstract class PostException extends ApplicationException {
+    protected PostException(String errorCode, HttpStatus httpStatus, String message) {
+        super(errorCode, httpStatus, message);
+    }
+}

--- a/src/main/java/porori/backend/community/config/exception/post/PostExceptionList.java
+++ b/src/main/java/porori/backend/community/config/exception/post/PostExceptionList.java
@@ -1,0 +1,14 @@
+package porori.backend.community.config.exception.post;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostExceptionList {
+    NOT_FOUND_POSTID_ERROR("P0001", HttpStatus.NOT_FOUND, "해당 postId로 Post를 찾을 수 없습니다.");
+    private final String errorCode;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/porori/backend/community/config/exception/user/JsonException.java
+++ b/src/main/java/porori/backend/community/config/exception/user/JsonException.java
@@ -1,9 +1,0 @@
-package porori.backend.community.config.exception.user;
-
-import static porori.backend.community.config.exception.user.UserExceptionList.JSON_ERROR;
-
-public class JsonException extends UserException{
-    public JsonException(){
-        super(JSON_ERROR.getErrorCode(), JSON_ERROR.getHttpStatus(), JSON_ERROR.getMessage());
-    }
-}

--- a/src/main/java/porori/backend/community/config/exception/user/UserBadGateWayException.java
+++ b/src/main/java/porori/backend/community/config/exception/user/UserBadGateWayException.java
@@ -1,0 +1,9 @@
+package porori.backend.community.config.exception.user;
+
+import static porori.backend.community.config.exception.user.UserExceptionList.USER_BAD_GATEWAY_ERROR;
+
+public class UserBadGateWayException extends UserException{
+    public UserBadGateWayException(){
+        super(USER_BAD_GATEWAY_ERROR.getErrorCode(), USER_BAD_GATEWAY_ERROR.getHttpStatus(), USER_BAD_GATEWAY_ERROR.getMessage());
+    }
+}

--- a/src/main/java/porori/backend/community/config/exception/user/UserExceptionList.java
+++ b/src/main/java/porori/backend/community/config/exception/user/UserExceptionList.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserExceptionList {
     TOKEN_ERROR("U0001", HttpStatus.UNAUTHORIZED, "AccessToken 값이 잘못되었습니다"),
-    JSON_ERROR("U0002", HttpStatus.BAD_REQUEST, "응답받은 Response의 JSON 값이 잘못되었습니다");
+    USER_BAD_GATEWAY_ERROR("U0002", HttpStatus.BAD_GATEWAY, "User 서버로부터 올바른 응답을 받지 못했습니다.");
     private final String errorCode;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/porori/backend/community/controller/BookmarkController.java
+++ b/src/main/java/porori/backend/community/controller/BookmarkController.java
@@ -1,0 +1,24 @@
+package porori.backend.community.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import porori.backend.community.config.BaseResponse;
+import porori.backend.community.dto.PostResDto;
+import porori.backend.community.service.BookmarkService;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/communities")
+@RestController
+@Tag(name = "Bookmark API", description = "북마크 API")
+public class BookmarkController {
+    private final BookmarkService bookmarkService;
+
+    //북마크 생성하기
+    @Operation(summary = "북마크 생성", description = "해당 postId에 북마크를 생성합니다.")
+    @PostMapping("/bookmark/{postId}")
+    public BaseResponse<PostResDto.PostContentRes> createBookmark(@RequestHeader("Authorization") String token, @PathVariable("postId") Long postId){
+        return new BaseResponse<>(bookmarkService.createBookmark(token, postId));
+    }
+}

--- a/src/main/java/porori/backend/community/domain/Bookmark.java
+++ b/src/main/java/porori/backend/community/domain/Bookmark.java
@@ -1,0 +1,34 @@
+package porori.backend.community.domain;
+
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import porori.backend.community.domain.core.BaseTimeEntity;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "bookmark")
+@DynamicInsert
+public class Bookmark extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bookmark_id")
+    private Long bookmarkId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id")
+    private Post postId;
+
+    @Column(nullable = false, name = "user_id")
+    private Long userId;
+
+    @Builder
+    public Bookmark(Post postId, Long userId) {
+        this.postId = postId;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/porori/backend/community/domain/user/UserInfo.java
+++ b/src/main/java/porori/backend/community/domain/user/UserInfo.java
@@ -1,0 +1,19 @@
+package porori.backend.community.domain.user;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInfo {
+    private Long userId;
+    private String name;
+    private String nickName;
+    private String phoneNumber;
+    private boolean gender;
+    private String address;
+    private String backgroundColor;
+    private String email;
+    private String imageUrl;
+}

--- a/src/main/java/porori/backend/community/repository/BookmarkRepository.java
+++ b/src/main/java/porori/backend/community/repository/BookmarkRepository.java
@@ -1,0 +1,11 @@
+package porori.backend.community.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import porori.backend.community.domain.Bookmark;
+import porori.backend.community.domain.Post;
+
+import java.util.Optional;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+    Optional<Bookmark> findByPostIdAndUserId(Post post, Long userId);
+}

--- a/src/main/java/porori/backend/community/repository/PostRepository.java
+++ b/src/main/java/porori/backend/community/repository/PostRepository.java
@@ -4,7 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import porori.backend.community.domain.Post;
 
+import java.util.Optional;
+
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+    Optional<Post> findByPostIdAndStatus(Long postId, String status);
 }

--- a/src/main/java/porori/backend/community/service/AmazonS3Service.java
+++ b/src/main/java/porori/backend/community/service/AmazonS3Service.java
@@ -19,12 +19,17 @@ import java.util.UUID;
 @Transactional
 public class AmazonS3Service {
     private final AmazonS3 amazonS3;
+    private final UserService userService;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
 
-    public PostResDto.PreSignedUrlRes getPreSignedUrl(){
+    public PostResDto.PreSignedUrlRes getPreSignedUrl(String token){
+        //토큰 유효 확인
+        userService.tokenValidationRequest(token);
+
+
         String uuid = UUID.randomUUID().toString();
         String objectKey = "communities/"+uuid;
 

--- a/src/main/java/porori/backend/community/service/BookmarkService.java
+++ b/src/main/java/porori/backend/community/service/BookmarkService.java
@@ -1,0 +1,54 @@
+package porori.backend.community.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import porori.backend.community.config.exception.bookmark.AlreadyBookmarkException;
+import porori.backend.community.config.exception.bookmark.MyPostException;
+import porori.backend.community.config.exception.post.NotFoundPostIdException;
+import porori.backend.community.domain.Bookmark;
+import porori.backend.community.domain.Post;
+import porori.backend.community.dto.PostResDto;
+import porori.backend.community.repository.BookmarkRepository;
+import porori.backend.community.repository.PostRepository;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BookmarkService {
+    private final BookmarkRepository bookmarkRepository;
+    private final PostRepository postRepository;
+
+    private final UserService userService;
+
+    public PostResDto.PostContentRes createBookmark(String token, Long postId){
+        //토큰 유효 확인
+        userService.tokenValidationRequest(token);
+
+        Post post = postRepository.findByPostIdAndStatus(postId, "ACTIVE").orElseThrow(NotFoundPostIdException::new);
+
+        //자기 게시글 확인
+        Long userId = userService.getUserId(token);
+        if(post.getUserId() == userId){
+            throw new MyPostException();
+        }
+        //이미 북마크 한거 확인
+         Optional<Bookmark> optional= bookmarkRepository.findByPostIdAndUserId(post, userId);
+        if(optional.isPresent()){
+            throw new AlreadyBookmarkException();
+        }
+
+        bookmarkRepository.save(Bookmark.builder()
+                .userId(userId)
+                .postId(post)
+                .build());
+
+        return new PostResDto.PostContentRes(post);
+
+    }
+}

--- a/src/main/java/porori/backend/community/service/TagService.java
+++ b/src/main/java/porori/backend/community/service/TagService.java
@@ -6,8 +6,8 @@ import porori.backend.community.domain.Tag;
 import porori.backend.community.repository.TagRepository;
 
 import javax.transaction.Transactional;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -16,12 +16,8 @@ public class TagService {
     private final TagRepository tagRepository;
 
     public List<Tag> saveTag(List<String> tagNameList){
-        List<Tag> tagList = new ArrayList<>();
-        for(String tagName: tagNameList){
-            Tag tag = tagRepository.findByName(tagName).orElseGet(()->tagRepository.save(Tag.builder().name(tagName).build()));
-
-            tagList.add(tag);
-        }
-        return tagList;
+        return tagNameList.stream()
+                .map(tagName -> tagRepository.findByName(tagName).orElseGet(()->tagRepository.save(Tag.builder().name(tagName).build())))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 🔥 Summary
- saveTag 로직 람다식으로 변경
- webClient의 response를 Object로 매핑
- 북마크 생성 API

## ✏️ Describe your changes
기존에 String으로 response를 처리하여 gson을 통해 JSON을 파싱했던 방법이 비효율적이라는 생각이 들어 webClient에서 ParameterizedTypeReference를 이용하여 response를 object로 매핑하는 방법으로 변경했습니다. 해당 과정에서 BaseResponse의 변수명을 User 서버와 동일하게 맞추었습니다.
https://github.com/Hey-Porori/Server_Community/blob/c667a3807a390bf356b1027604064f836aa7b7e3/src/main/java/porori/backend/community/service/UserService.java#L32-L46  </br>


북마크를 생성할 때 자신의 게시물인 경우와 이미 자신이 북마크한 게시물일 경우는 북마크 생성이 다시 되지 않도록 설계했습니다.
https://github.com/Hey-Porori/Server_Community/blob/c667a3807a390bf356b1027604064f836aa7b7e3/src/main/java/porori/backend/community/service/BookmarkService.java#L35-L44 </br>

## 📖 Review Point
- 북마크를 생성할 때 자신의 게시물인 경우와 자신이 북마크한 게시물일 경우 북마크가 중복되어 생성되지 않도록 하기 위해 Exception을 발생시켜 요청에 실패하도록 처리했는데 해당 로직이 맞는 건지 모르겠습니다..  </br>
1. Exception을 발생시켜 요청에 실패하도록 처리해야 하는 건지
2. 요청은 성공하게 하되(httpStatusCode == 200) 북마크는 생성되지 않게 해야 하는 건지 의견 부탁드립니다..!